### PR TITLE
Апдейт style.css пофіксив обертання пімпочки

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -172,7 +172,17 @@ input[type="checkbox"]:checked~.vinyl__disk .vinyl__logo {
     animation-duration: 3s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
-    animation-delay: 3s;
+    animation-delay: 1s;
+
+}
+
+input[type="checkbox"]:checked~.vinyl__disk .vinyl__logo::before{
+    animation-name: turn_logo;
+    animation-duration: 3s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-delay: 1s;
+    animation-direction: reverse;
 
 }
 


### PR DESCRIPTION
Зменшив animation-delay логотипу пластинки з 3 сек до 1 сек.
Додав анімацію обертання пімпочки пластинки в зворотньому напрямку до обертання логотипа, так зщо здається, наче вона залишається на місці